### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "spatie/laravel-package-tools": "^1.14.0",
+        "illuminate/contracts": "^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.14.0",
+        "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Error:
``` 
Problem 1
    - Root composer.json requires illuminate/contracts ^10.0, found illuminate/contracts[v10.0.0, ..., v10.48.3] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - Root composer.json requires grantholle/laravel-altcha * -> satisfiable by grantholle/laravel-altcha[1.0.0].
    - grantholle/laravel-altcha 1.0.0 requires illuminate/contracts ^10.0 -> found illuminate/contracts[v10.0.0, ..., v10.48.3] but these were not loaded, likely because it conflicts with another require.
```

- "illuminate/contracts" is now included in Laravel 11.
