### PR TITLE
[2.x] refactor: Leverage the official altcha-org/altcha underlying library

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,6 @@ on:
       - '.github/workflows/run-tests.yml'
       - 'phpunit.xml.dist'
       - 'composer.json'
-      - 'composer.lock'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const form = useForm({
 
 ## Backend validation
 
-To validate the frontend-generated token/payload, there's a `ValidAltcha` rule you can use, assuming the token is passed as `altcha` in the request:
+To validate the frontend-generated token/payload, there's a `ValidAltcha` rule you can use, assuming the token is passed as `token` in the request:
 
 ```php
 use GrantHolle\Altcha\Rules\ValidAltcha;
@@ -101,7 +101,7 @@ use GrantHolle\Altcha\Rules\ValidAltcha;
 $request->validate([
     'email' => ['required', 'email'],
     'password' => ['required'],
-    'altcha' => ['required', new ValidAltcha()],
+    'token' => ['required', new ValidAltcha()],
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const form = useForm({
 
 ## Backend validation
 
-To validate the frontend-generated token/payload, there's a `ValidAltcha` rule you can use, assuming the token is passed as `token` in the request:
+To validate the frontend-generated token/payload, there's a `ValidAltcha` rule you can use, assuming the token is passed as `altcha` in the request:
 
 ```php
 use GrantHolle\Altcha\Rules\ValidAltcha;

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ use GrantHolle\Altcha\Rules\ValidAltcha;
 $request->validate([
     'email' => ['required', 'email'],
     'password' => ['required'],
-    'token' => ['required', new ValidAltcha()],
+    'token' => ['required', new ValidAltcha],
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In `.env` (or published config file), set the following variables:
 ```dotenv
 # Required, sort of like a password
 ALTCHA_HMAC_KEY=
-# Optional, defaults to SHA-256. Can be SHA-384 or SHA-512
+# Optional, defaults to SHA-256. Can be SHA-1 or SHA-512
 # ALTCHA_ALGORITHM="SHA-256"
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         "php": "^8.2",
         "altcha-org/altcha": "^1.1",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "laravel/framework": "10.*",
+        "orchestra/testbench": "8.*",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
         "pestphp/pest": "^3.0||^2.0",
         "pestphp/pest-plugin-arch": "^3.0||^2.0",
-        "pestphp/pest-plugin-laravel": "^3.0||^2.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     ],
     "require": {
         "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "altcha-org/altcha": "^1.1",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,16 @@
     ],
     "require": {
         "php": "^8.2",
-        "altcha-org/altcha": "^1.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "laravel/framework": "10.*",
-        "orchestra/testbench": "8.*",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "spatie/laravel-package-tools": "^1.14.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
+        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
         "pestphp/pest": "^3.0||^2.0",
         "pestphp/pest-plugin-arch": "^3.0||^2.0",
+        "pestphp/pest-plugin-laravel": "^3.0||^2.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/config/altcha.php
+++ b/config/altcha.php
@@ -6,7 +6,7 @@ return [
      * The algorithm to use for hashing the challenge.
      * Should be SHA-256, SHA-384 or SHA-512.
      */
-    'algorithm' => env('ALTCHA_ALGORITHM', 'SHA-256'),
+    'algorithm' => env('ALTCHA_ALGORITHM', \AltchaOrg\Altcha\Hasher\Algorithm::SHA256),
 
     /*
      * The secret key to use for hashing the challenge.
@@ -14,18 +14,16 @@ return [
     'hmac_key' => env('ALTCHA_HMAC_KEY'),
 
     /*
-     * The minimum and maximum values for the challenge.
+     * The maximum value for the challenge.
      * The bigger larger the number, the more difficult the challenge.
      */
-    'range_min' => env('ALTCHA_RANGE_MIN', 1e3),
-
-    'range_max' => env('ALTCHA_RANGE_MAX', 1e5),
+    'range_max' => env('ALTCHA_RANGE_MAX', \AltchaOrg\Altcha\ChallengeOptions::DEFAULT_MAX_NUMBER),
 
     /*
      * The expiration time for the challenge in seconds.
      * Set to null to disable expiration.
      */
-    'expires' => env('ALTCHA_EXPIRES', 60),
+    'expires' => env('ALTCHA_EXPIRES', 10),
 
     /*
      * The length of the salt to use for the challenge.
@@ -43,4 +41,5 @@ return [
      * The middleware to use for the challenge endpoint.
      */
     'middleware' => ['web', 'throttle:10,1'],
+
 ];

--- a/config/altcha.php
+++ b/config/altcha.php
@@ -6,7 +6,7 @@ return [
      * The algorithm to use for hashing the challenge.
      * Should be SHA-256, SHA-384 or SHA-512.
      */
-    'algorithm' => env('ALTCHA_ALGORITHM', \AltchaOrg\Altcha\Hasher\Algorithm::SHA256),
+    'algorithm' => env('ALTCHA_ALGORITHM', 'SHA-256'),
 
     /*
      * The secret key to use for hashing the challenge.

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -5,37 +5,29 @@ namespace GrantHolle\Altcha;
 use AltchaOrg\Altcha\BaseChallengeOptions;
 use AltchaOrg\Altcha\ChallengeOptions;
 use AltchaOrg\Altcha\Hasher\Algorithm;
-use GrantHolle\Altcha\Exceptions\InvalidAlgorithmException;
 
 class Altcha
 {
-    public \AltchaOrg\Altcha\Altcha $altcha;
-
     public function __construct(
-        protected string $algorithm,
-        protected string $key,
+        protected \AltchaOrg\Altcha\Altcha $altcha,
+        protected Algorithm $algorithm,
         protected int $rangeMax,
     ) {
-        $this->altcha = new \AltchaOrg\Altcha\Altcha($this->key);
+        //
     }
 
+    /**
+     * @var int|null $expiration
+     * @return array
+     */
     public function createChallenge(?int $expiration = null): array
     {
-        $algorithm = match (strtolower($this->algorithm)) {
-            'sha-1' => Algorithm::SHA1,
-            'sha-256' => Algorithm::SHA256,
-            'sha-512' => Algorithm::SHA512,
-            default => throw new InvalidAlgorithmException('Algorithm must be set to SHA-1, SHA-256 or SHA-512.'),
-        };
-
-        if ($expiration || is_int(config('altcha.expires'))) {
-            $seconds = config('altcha.expires', $expiration);
-        }
+        $seconds = $expiration ?? config('altcha.expires');
 
         $challenge = $this->altcha->createChallenge(new ChallengeOptions(
-            algorithm: $algorithm,
+            algorithm: $this->algorithm,
             maxNumber: $this->rangeMax ?? BaseChallengeOptions::DEFAULT_MAX_NUMBER,
-            expires: (new \DateTimeImmutable())->add(new \DateInterval("PT{$seconds}S")),
+            expires: $seconds ? (new \DateTimeImmutable())->add(new \DateInterval("PT{$seconds}S")) : null,
             saltLength: config('altcha.salt_length')
         ));
 
@@ -47,8 +39,8 @@ class Altcha
      * @var bool $checkExpires
      * @return bool
      */
-    public function verifySolution(mixed $payload, bool $checkExpires = true): bool
+    public function verifySolution(mixed $payload): bool
     {
-        return $this->altcha->verifySolution($payload, $checkExpires);
+        return $this->altcha->verifySolution($payload);
     }
 }

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -5,12 +5,13 @@ namespace GrantHolle\Altcha;
 use AltchaOrg\Altcha\BaseChallengeOptions;
 use AltchaOrg\Altcha\ChallengeOptions;
 use AltchaOrg\Altcha\Hasher\Algorithm;
+use GrantHolle\Altcha\Exceptions\InvalidAlgorithmException;
 
 class Altcha
 {
     public function __construct(
         protected \AltchaOrg\Altcha\Altcha $altcha,
-        protected Algorithm $algorithm,
+        protected string $algorithm,
         protected int $rangeMax,
         protected int $saltLength,
         protected ?int $expires = null,
@@ -21,13 +22,20 @@ class Altcha
     /**
      * @var int|null $expiration
      * @return array
+     * @throws \GrantHolle\Altcha\Exceptions\InvalidAlgorithmException
      */
     public function createChallenge(?int $expiration = null): array
     {
         $seconds = $expiration ?? $this->expires;
+        $algorithm = match (strtolower($this->algorithm)) {
+            'sha-1' => Algorithm::SHA1,
+            'sha-256' => Algorithm::SHA256,
+            'sha-512' => Algorithm::SHA512,
+            default => throw new InvalidAlgorithmException('Algorithm must be set to SHA-1, SHA-256 or SHA-512.'),
+        };
 
         $challenge = $this->altcha->createChallenge(new ChallengeOptions(
-            algorithm: $this->algorithm,
+            algorithm: $algorithm,
             maxNumber: $this->rangeMax ?? BaseChallengeOptions::DEFAULT_MAX_NUMBER,
             expires: $seconds ? (new \DateTimeImmutable())->add(new \DateInterval("PT{$seconds}S")) : null,
             saltLength: $this->saltLength,

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -2,67 +2,53 @@
 
 namespace GrantHolle\Altcha;
 
+use AltchaOrg\Altcha\BaseChallengeOptions;
+use AltchaOrg\Altcha\ChallengeOptions;
+use AltchaOrg\Altcha\Hasher\Algorithm;
 use GrantHolle\Altcha\Exceptions\InvalidAlgorithmException;
-use Illuminate\Support\Str;
 
 class Altcha
 {
+    public \AltchaOrg\Altcha\Altcha $altcha;
+
     public function __construct(
         protected string $algorithm,
         protected string $key,
-        protected int $rangeMin,
         protected int $rangeMax,
-    ) {}
+    ) {
+        $this->altcha = new \AltchaOrg\Altcha\Altcha($this->key);
+    }
 
-    public function createChallenge(?string $salt = null, ?int $number = null, ?int $expiration = null): array
+    public function createChallenge(?int $expiration = null): array
     {
-        $salt = $salt ?? bin2hex(random_bytes(config('altcha.salt_length')));
-        $number = $number ?? random_int($this->rangeMin, $this->rangeMax);
-
         $algorithm = match (strtolower($this->algorithm)) {
-            'sha-256' => 'sha256',
-            'sha-384' => 'sha384',
-            'sha-512' => 'sha512',
-            default => throw new InvalidAlgorithmException('Algorithm must be set to SHA-256, SHA-384 or SHA-512.'),
+            'sha-1' => Algorithm::SHA1,
+            'sha-256' => Algorithm::SHA256,
+            'sha-512' => Algorithm::SHA512,
+            default => throw new InvalidAlgorithmException('Algorithm must be set to SHA-1, SHA-256 or SHA-512.'),
         };
 
         if ($expiration || is_int(config('altcha.expires'))) {
-            $salt .= '?expires='.($expiration ?? (time() + config('altcha.expires')));
+            $seconds = config('altcha.expires', $expiration);
         }
 
-        $challenge = hash($algorithm, $salt.$number);
-        $signature = hash_hmac($algorithm, $challenge, $this->key);
+        $challenge = $this->altcha->createChallenge(new ChallengeOptions(
+            algorithm: $algorithm,
+            maxNumber: $this->rangeMax ?? BaseChallengeOptions::DEFAULT_MAX_NUMBER,
+            expires: (new \DateTimeImmutable())->add(new \DateInterval("PT{$seconds}S")),
+            saltLength: config('altcha.salt_length')
+        ));
 
-        return [
-            'algorithm' => $this->algorithm,
-            'challenge' => $challenge,
-            'salt' => $salt,
-            'signature' => $signature,
-        ];
+        return get_object_vars($challenge);
     }
 
-    public function validPayload(string $payload): bool
+    /**
+     * @var array|string $payload
+     * @var bool $checkExpires
+     * @return bool
+     */
+    public function verifySolution(mixed $payload, bool $checkExpires = true): bool
     {
-        $json = json_decode(base64_decode($payload), true);
-
-        if ($json !== null) {
-            $salt = Str::before($json['salt'], '?');
-            parse_str(Str::after($json['salt'], '?'), $params);
-            $expiration = isset($params['expires'])
-                ? (int) $params['expires']
-                : null;
-
-            if (! is_null($expiration) && $expiration < time()) {
-                return false;
-            }
-
-            $check = $this->createChallenge($salt, $json['number'], $expiration);
-
-            return $json['algorithm'] === $check['algorithm']
-                && $json['challenge'] === $check['challenge']
-                && $json['signature'] === $check['signature'];
-        }
-
-        return false;
+        return $this->altcha->verifySolution($payload, $checkExpires);
     }
 }

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -12,6 +12,8 @@ class Altcha
         protected \AltchaOrg\Altcha\Altcha $altcha,
         protected Algorithm $algorithm,
         protected int $rangeMax,
+        protected int $saltLength,
+        protected ?int $expires = null,
     ) {
         //
     }
@@ -22,13 +24,13 @@ class Altcha
      */
     public function createChallenge(?int $expiration = null): array
     {
-        $seconds = $expiration ?? config('altcha.expires');
+        $seconds = $expiration ?? $this->expires;
 
         $challenge = $this->altcha->createChallenge(new ChallengeOptions(
             algorithm: $this->algorithm,
             maxNumber: $this->rangeMax ?? BaseChallengeOptions::DEFAULT_MAX_NUMBER,
             expires: $seconds ? (new \DateTimeImmutable())->add(new \DateInterval("PT{$seconds}S")) : null,
-            saltLength: config('altcha.salt_length')
+            saltLength: $this->saltLength,
         ));
 
         return get_object_vars($challenge);

--- a/src/AltchaServiceProvider.php
+++ b/src/AltchaServiceProvider.php
@@ -17,11 +17,14 @@ class AltchaServiceProvider extends PackageServiceProvider
 
     public function packageRegistered()
     {
-        $this->app->bind(\AltchaOrg\Altcha\Altcha::class, fn () => new \AltchaOrg\Altcha\Altcha(config('altcha.hmac_key')));
+        $this->app->bind(\AltchaOrg\Altcha\Altcha::class, fn () => new \AltchaOrg\Altcha\Altcha(
+            config('altcha.hmac_key')
+        ));
+
         $this->app->bind(Altcha::class, fn (Application $app) => new Altcha(
             $app->make(\AltchaOrg\Altcha\Altcha::class),
             $app['config']->get('altcha.algorithm'),
-            $app['config']->get('altcha.range_max'),
+            $app['config']->get('altcha.range_max')
         ));
     }
 

--- a/src/AltchaServiceProvider.php
+++ b/src/AltchaServiceProvider.php
@@ -11,14 +11,7 @@ class AltchaServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        /*
-         * This class is a Package Service Provider
-         *
-         * More info: https://github.com/spatie/laravel-package-tools
-         */
-        $package
-            ->name('laravel-altcha')
-            ->hasConfigFile();
+        $package->name('laravel-altcha')->hasConfigFile();
     }
 
     public function packageRegistered()
@@ -26,7 +19,6 @@ class AltchaServiceProvider extends PackageServiceProvider
         $this->app->bind(Altcha::class, fn () => new Altcha(
             config('altcha.algorithm'),
             config('altcha.hmac_key'),
-            config('altcha.range_min'),
             config('altcha.range_max'),
         ));
     }

--- a/src/AltchaServiceProvider.php
+++ b/src/AltchaServiceProvider.php
@@ -3,6 +3,7 @@
 namespace GrantHolle\Altcha;
 
 use GrantHolle\Altcha\Http\Controllers\AltchaChallengeController;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -16,10 +17,11 @@ class AltchaServiceProvider extends PackageServiceProvider
 
     public function packageRegistered()
     {
-        $this->app->bind(Altcha::class, fn () => new Altcha(
-            config('altcha.algorithm'),
-            config('altcha.hmac_key'),
-            config('altcha.range_max'),
+        $this->app->bind(\AltchaOrg\Altcha\Altcha::class, fn () => new \AltchaOrg\Altcha\Altcha(config('altcha.hmac_key')));
+        $this->app->bind(Altcha::class, fn (Application $app) => new Altcha(
+            $app->make(\AltchaOrg\Altcha\Altcha::class),
+            $app['config']->get('altcha.algorithm'),
+            $app['config']->get('altcha.range_max'),
         ));
     }
 

--- a/src/AltchaServiceProvider.php
+++ b/src/AltchaServiceProvider.php
@@ -24,7 +24,9 @@ class AltchaServiceProvider extends PackageServiceProvider
         $this->app->bind(Altcha::class, fn (Application $app) => new Altcha(
             $app->make(\AltchaOrg\Altcha\Altcha::class),
             $app['config']->get('altcha.algorithm'),
-            $app['config']->get('altcha.range_max')
+            $app['config']->get('altcha.range_max'),
+            $app['config']->get('altcha.salt_length'),
+            $app['config']->get('altcha.expires')
         ));
     }
 

--- a/src/Exceptions/InvalidAlgorithmException.php
+++ b/src/Exceptions/InvalidAlgorithmException.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace GrantHolle\Altcha\Exceptions;
-
-class InvalidAlgorithmException extends \Exception {}

--- a/src/Exceptions/InvalidAlgorithmException.php
+++ b/src/Exceptions/InvalidAlgorithmException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace GrantHolle\Altcha\Exceptions;
+
+class InvalidAlgorithmException extends \Exception {}

--- a/src/Http/Controllers/AltchaChallengeController.php
+++ b/src/Http/Controllers/AltchaChallengeController.php
@@ -3,17 +3,12 @@
 namespace GrantHolle\Altcha\Http\Controllers;
 
 use GrantHolle\Altcha\Altcha;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
 class AltchaChallengeController extends Controller
 {
-    /**
-     * Handle the incoming request.
-     */
-    public function __invoke(Request $request)
+    public function __invoke(Altcha $altcha)
     {
-        return app(Altcha::class)
-            ->createChallenge();
+        return $altcha->createChallenge();
     }
 }

--- a/src/Rules/ValidAltcha.php
+++ b/src/Rules/ValidAltcha.php
@@ -8,12 +8,14 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class ValidAltcha implements ValidationRule
 {
-    /**
-     * Run the validation rule.
-     */
+    public function __construct(protected Altcha $altcha)
+    {
+        //
+    }
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! app(Altcha::class)->validPayload($value)) {
+        if (! $this->altcha->verifySolution($value)) {
             $fail('Invalid captcha.');
         }
     }

--- a/src/Rules/ValidAltcha.php
+++ b/src/Rules/ValidAltcha.php
@@ -8,9 +8,11 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class ValidAltcha implements ValidationRule
 {
-    public function __construct(protected Altcha $altcha)
+    protected Altcha $altcha;
+
+    public function __construct()
     {
-        //
+        $this->altcha = app(Altcha::class);
     }
 
     public function validate(string $attribute, mixed $value, Closure $fail): void

--- a/tests/AltchaTest.php
+++ b/tests/AltchaTest.php
@@ -80,21 +80,6 @@ it('does not require expires parameter', function () {
     expect($passes)->toBeTrue();
 });
 
-it('can ignore the expiration when verifying the solution', function () {
-    config(['altcha.expires' => 1]);
-    $challenge = app(Altcha::class)->createChallenge();
-    expect($challenge['salt'])->toContain('expires');
-
-    sleep(2);
-    $passes = Validator::make([
-        'payload' => solve($challenge),
-    ], [
-        'payload' => [new ValidAltcha(false)],
-    ])->passes();
-
-    expect($passes)->toBeTrue();
-});
-
 function solve(array $challenge): string
 {
     $solution = app(\AltchaOrg\Altcha\Altcha::class)->solveChallenge(
@@ -104,7 +89,7 @@ function solve(array $challenge): string
         $challenge['maxNumber']
     );
 
-    $challenge['number'] = $solution['number'];
+    $challenge['number'] = $solution->number;
 
     return base64_encode(json_encode($challenge));
 }

--- a/tests/AltchaTest.php
+++ b/tests/AltchaTest.php
@@ -2,6 +2,7 @@
 
 use AltchaOrg\Altcha\Hasher\Algorithm;
 use GrantHolle\Altcha\Altcha;
+use GrantHolle\Altcha\Exceptions\InvalidAlgorithmException;
 use GrantHolle\Altcha\Rules\ValidAltcha;
 use Illuminate\Support\Facades\Validator;
 
@@ -101,6 +102,12 @@ it('can use a specific expiration duration in seconds when generating a challeng
     $expires = Str::of($challenge['salt'])->after('?expires=')->toInteger();
     expect($expires)->toBeGreaterThanOrEqual($now + 12);
 });
+
+it("throws when the algorithm isn't supported", function () {
+    config(['altcha.algorithm' => 'foobar']);
+
+    app(Altcha::class)->createChallenge();
+})->throws(InvalidAlgorithmException::class);
 
 function solve(array $challenge): string
 {

--- a/tests/AltchaTest.php
+++ b/tests/AltchaTest.php
@@ -10,31 +10,27 @@ it('can generate challenge', function () {
     expect($challenge)->toHaveKeys([
         'algorithm',
         'challenge',
+        'maxNumber',
         'salt',
         'signature',
     ]);
 });
 
 it('can use endpoint to get challenge', function () {
-    $this->get(route('altcha-challenge'))
-        ->assertOk()
-        ->assertJsonStructure([
-            'algorithm',
-            'challenge',
-            'salt',
-            'signature',
-        ]);
+    $this->get(route('altcha-challenge'))->assertOk()->assertJsonStructure([
+        'algorithm',
+        'challenge',
+        'maxNumber',
+        'salt',
+        'signature',
+    ]);
 });
 
 it('can validate challenge using rule', function () {
-    $challenge = app(Altcha::class)
-        ->createChallenge(number: 10);
-    sleep(1);
-    $challenge['number'] = 10;
-    $encoded = base64_encode(json_encode($challenge));
+    $challenge = app(Altcha::class)->createChallenge();
 
     $passes = Validator::make([
-        'payload' => $encoded,
+        'payload' => solve($challenge),
     ], [
         'payload' => [new ValidAltcha],
     ])->passes();
@@ -43,13 +39,11 @@ it('can validate challenge using rule', function () {
 });
 
 it('can fail validation with incorrect challenge', function () {
-    $challenge = app(Altcha::class)
-        ->createChallenge(number: 10);
-    $challenge['number'] = 11;
-    $encoded = base64_encode(json_encode($challenge));
+    $challenge = app(Altcha::class)->createChallenge();
+    $challenge['number'] = 9999999999999;
 
     $passes = Validator::make([
-        'payload' => $encoded,
+        'payload' => base64_encode(json_encode($challenge)),
     ], [
         'payload' => [new ValidAltcha],
     ])->passes();
@@ -58,17 +52,13 @@ it('can fail validation with incorrect challenge', function () {
 });
 
 it('can fail validation past expiration', function () {
-    // Set a negative expiration time to force failure
-    config()->set('altcha.expires', -10);
-
-    $challenge = app(Altcha::class)
-        ->createChallenge(number: 10);
-    $challenge['number'] = 10;
+    config(['altcha.expires' => 1]);
+    $challenge = app(Altcha::class)->createChallenge();
     expect($challenge['salt'])->toContain('expires');
-    $encoded = base64_encode(json_encode($challenge));
 
+    sleep(2);
     $passes = Validator::make([
-        'payload' => $encoded,
+        'payload' => solve($challenge),
     ], [
         'payload' => [new ValidAltcha],
     ])->passes();
@@ -77,19 +67,44 @@ it('can fail validation past expiration', function () {
 });
 
 it('does not require expires parameter', function () {
-    config()->set('altcha.expires', null);
-
-    $challenge = app(Altcha::class)
-        ->createChallenge(number: 10);
-    $challenge['number'] = 10;
-
+    config(['altcha.expires' => null]);
+    $challenge = app(Altcha::class)->createChallenge();
     expect($challenge['salt'])->not->toContain('expires');
 
     $passes = Validator::make([
-        'payload' => base64_encode(json_encode($challenge)),
+        'payload' => solve($challenge),
     ], [
         'payload' => [new ValidAltcha],
     ])->passes();
 
     expect($passes)->toBeTrue();
 });
+
+it('can ignore the expiration when verifying the solution', function () {
+    config(['altcha.expires' => 1]);
+    $challenge = app(Altcha::class)->createChallenge();
+    expect($challenge['salt'])->toContain('expires');
+
+    sleep(2);
+    $passes = Validator::make([
+        'payload' => solve($challenge),
+    ], [
+        'payload' => [new ValidAltcha(false)],
+    ])->passes();
+
+    expect($passes)->toBeTrue();
+});
+
+function solve(array $challenge): string
+{
+    $solution = app(\AltchaOrg\Altcha\Altcha::class)->solveChallenge(
+        $challenge['challenge'],
+        $challenge['salt'],
+        config('altcha.algorithm'),
+        $challenge['maxNumber']
+    );
+
+    $challenge['number'] = $solution['number'];
+
+    return base64_encode(json_encode($challenge));
+}

--- a/tests/AltchaTest.php
+++ b/tests/AltchaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use AltchaOrg\Altcha\Hasher\Algorithm;
 use GrantHolle\Altcha\Altcha;
 use GrantHolle\Altcha\Rules\ValidAltcha;
 use Illuminate\Support\Facades\Validator;
@@ -106,7 +107,7 @@ function solve(array $challenge): string
     $solution = app(\AltchaOrg\Altcha\Altcha::class)->solveChallenge(
         $challenge['challenge'],
         $challenge['salt'],
-        config('altcha.algorithm'),
+        Algorithm::SHA256,
         $challenge['maxNumber']
     );
 

--- a/tests/AltchaTest.php
+++ b/tests/AltchaTest.php
@@ -80,6 +80,27 @@ it('does not require expires parameter', function () {
     expect($passes)->toBeTrue();
 });
 
+it('can use a specific salt length', function () {
+    config(['altcha.expires' => null, 'altcha.salt_length' => 12]);
+    $challenge = app(Altcha::class)->createChallenge();
+    expect($challenge['salt'])->toHaveLength(24);
+
+    config(['altcha.expires' => null, 'altcha.salt_length' => 24]);
+    $challenge = app(Altcha::class)->createChallenge();
+    expect($challenge['salt'])->toHaveLength(48);
+});
+
+it('can use a specific expiration duration in seconds when generating a challenge', function () {
+    config(['altcha.expires' => 10]);
+    $now = time();
+
+    $challenge = app(Altcha::class)->createChallenge(12);
+    expect($challenge['salt'])->toContain('expires');
+
+    $expires = Str::of($challenge['salt'])->after('?expires=')->toInteger();
+    expect($expires)->toBeGreaterThanOrEqual($now + 12);
+});
+
 function solve(array $challenge): string
 {
     $solution = app(\AltchaOrg\Altcha\Altcha::class)->solveChallenge(


### PR DESCRIPTION
Follow up from #16:

- requiring https://github.com/altcha-org/altcha-lib-php
- delegating the challenge generation and validation to the library
- simplifying the wrapper by using the underlying library
  - it only supports SHA-1, SHA-256 or SHA-512
  - it uses 10 seconds expiration by default (still optional)
  - it provides a default for `altcha.range_max`
  - it doesn't support `altcha.range_min`
- updating the tests accordingly and add new ones

This is probably a candidate for a `2.x` as it introduces a breaking change around the two methods we had from the original class:

From

```php
public function createChallenge(?string $salt = null, ?int $number = null, ?int $expiration = null): array;
public function validPayload(string $payload): bool;
```

To

```php
public function createChallenge(?int $expiration = null): array;
public function verifySolution(mixed $payload): bool;
```

I could keep `validPayload()` called this way but the underlying function accepts either an `array` or a `string` (mixed) so I thought we might wanna stick with the underlying API too for the name too.

The rest is pretty much the same from a consumer point of view.

Let me know what you think. :v: